### PR TITLE
Add responsive feature to index.html and profile.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
           src="./static/catbanner_1.jpg"
           alt="Profile text with a cat image."
         />
-        <p>This is my profile!</p>
+        <p class="profile-text">This is my profile!</p>
         <button><a class="profile-btn" href="./profile.html">Look profile</a></button>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -200,15 +200,18 @@ td {
 
 /* Responsive with breakpoint at 980px width for SP*/
 @media (max-width: 980px) {
+    /* Responsive Header Navigation Bar */
     .nav-header {
         text-align: left;
     }
 
+    /* Responsive Introduction Image */
     .intro-img {
         height: 100vh;
         object-fit: cover;
     }
 
+    /* Responsive Profile Content */
     .profile-content {
         width: auto;
         height: auto;
@@ -231,6 +234,7 @@ td {
         font-size: 19px;
     }
 
+    /* Responsive Footer Navigation Bar */
     .nav-footer {
         text-align: left;
     }

--- a/style.css
+++ b/style.css
@@ -230,4 +230,8 @@ td {
         padding: 15px 35px;
         font-size: 19px;
     }
+
+    .nav-footer {
+        text-align: left;
+    }
 }

--- a/style.css
+++ b/style.css
@@ -197,9 +197,14 @@ td {
     width: 30%;
 }
 
-/* Responsive with breakpoint at 980px width*/
+/* Responsive with breakpoint at 980px width for SP*/
 @media (max-width: 980px) {
     .nav-header {
         text-align: left;
+    }
+
+    .intro-img {
+        height: 100vh;
+        object-fit: cover;
     }
 }

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ body {
 
 .nav-header ul {
     list-style: none;
-    margin: 13px;
+    margin: 16px;
     padding: 0;
     display: inline-block;
 }
@@ -195,4 +195,11 @@ td {
 
 .left-col {
     width: 30%;
+}
+
+/* Responsive with breakpoint at 980px width*/
+@media (max-width: 980px) {
+    .nav-header {
+        text-align: left;
+    }
 }

--- a/style.css
+++ b/style.css
@@ -113,6 +113,7 @@ button {
     font-size: 16px;
     border-radius: 12px;
     border: none;
+    font-family: 'Libre Baskerville', serif;
 }
 
 .profile-btn {
@@ -206,5 +207,27 @@ td {
     .intro-img {
         height: 100vh;
         object-fit: cover;
+    }
+
+    .profile-content {
+        width: auto;
+        height: auto;
+        border: none;
+    }
+
+    .profile-img {
+        width: 60%;
+        border: solid 3px;
+        float: none;
+    }
+
+    .profile-text {
+        margin: 52px 0;
+        font-size: 19px;
+    }
+
+    button {
+        padding: 15px 35px;
+        font-size: 19px;
     }
 }

--- a/style.css
+++ b/style.css
@@ -238,4 +238,9 @@ td {
     .nav-footer {
         text-align: left;
     }
+
+    /* Responsive Profile Table */
+    .profile-table-container {
+        width: 95%;
+    }
 }


### PR DESCRIPTION
## Why
index.htmlとprofile.htmlにレスポンシブ機能の追加。

## What
レスポンシブの場合:
- Header-navとFooter-navのテキスト配置を左に。
[Header-nav]
![image](https://github.com/I-BIS-company/kawakami-kadai/assets/132991861/53767467-9609-46b1-936b-0f65153ec22a)
[Footer-nav]
![image](https://github.com/I-BIS-company/kawakami-kadai/assets/132991861/575fbbbc-6e2c-4b37-8a70-9674e7109ab6)

- Intro-imgのサイズ変更。
![image](https://github.com/I-BIS-company/kawakami-kadai/assets/132991861/ffccf9bc-6ce0-447f-a1eb-8656a2fb6bd7)

- .profile-contentの配置変更。
![image](https://github.com/I-BIS-company/kawakami-kadai/assets/132991861/2cca1d43-fba9-44ae-ab23-29b361916595)

- profile.htmlのテーブルサイズ変更。
![image](https://github.com/I-BIS-company/kawakami-kadai/assets/132991861/efc6d605-5a9b-48c5-9a96-77a2009f83c5)
